### PR TITLE
feat: support new token format of token['access_token']

### DIFF
--- a/casdoor_auth/views.py
+++ b/casdoor_auth/views.py
@@ -40,6 +40,8 @@ def toLogin(request):
 def callback(request):
     code = request.GET.get('code')
     token = sdk.get_oauth_token(code)
+    if isinstance(token, dict) and 'access_token' in token:
+        token = token['access_token']
     user = sdk.parse_jwt_token(token)
     request.session['user'] = user
     try:


### PR DESCRIPTION
Fix new version returns dict data containing token. It is a question of using it directly as a string. #7 

Fix: https://github.com/casdoor/django-casdoor-auth/issues/7